### PR TITLE
Fix: improve storage of context string for relevancy tasks

### DIFF
--- a/deval/task_generator.py
+++ b/deval/task_generator.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     from deval.llms.config import LLMArgs, LLMFormatType, LLMAPIs
     from dotenv import load_dotenv, find_dotenv
     
-    task_name = TasksEnum.HALLUCINATION.value
+    task_name = TasksEnum.RELEVANCY.value
     _ = load_dotenv(find_dotenv())
 
 

--- a/deval/tasks/relevancy.py
+++ b/deval/tasks/relevancy.py
@@ -76,7 +76,8 @@ class RelevancyTask(Task):
     penalty_definition = []
 
     def __init__(self, llm_pipeline, context):
-        self.context = context.content
+        content = context.content
+        self.context = context
         
         system_prompt = RELEVANCY_SYSTEM_PROMPT
         probability_relevant = random.random()
@@ -92,7 +93,7 @@ class RelevancyTask(Task):
 
         # format 
         json_response = self.parse_llm_query(response)
-        json_response['context'] = self.context
+        json_response['context'] = content
         json_response['relevant_or_not'] = relevant_or_not
         response = Config(**json_response)
         

--- a/deval/tools/datasets/wiki.py
+++ b/deval/tools/datasets/wiki.py
@@ -97,20 +97,25 @@ def process_page(
     header = ""
     sections = {}
 
-    for section_title in page.sections:
-        content = page.section(section_title)
-        if not content:
-            header = section_title
-            continue
+    sections_list = page.sections
 
-        # Filter out sections that don't match the headers and/or are not valid
-        if (valid_header and not valid_header(header)) or (
-            valid_content and not valid_content(content)
-        ):
-            continue
+    if len(sections) > 0:
+        for section_title in sections_list:
+            content = page.section(section_title)
+            if not content:
+                header = section_title
+                continue
 
-        key = (header, section_title)
-        sections[key] = content.splitlines()
+            # Filter out sections that don't match the headers and/or are not valid
+            if (valid_header and not valid_header(header)) or (
+                valid_content and not valid_content(content)
+            ):
+                continue
+
+            key = (header, section_title)
+            sections[key] = content.splitlines()
+    else:
+        sections[("wiki", "whole_page")] = page.content.splitlines()
 
     if not sections:
         bt.logging.debug(f"No valid sections found in page {page.title!r} ({page.url})")

--- a/scripts/generate_task_examples.py
+++ b/scripts/generate_task_examples.py
@@ -8,7 +8,7 @@ _ = load_dotenv(find_dotenv())
 
 # INIT Variables
 task_name = TasksEnum.RELEVANCY.value
-num_to_generate = 7
+num_to_generate = 3
 data_path = "./exports"
 
 def extractTaskToRow(task, llm_pipeline):
@@ -24,8 +24,8 @@ def extractTaskToRow(task, llm_pipeline):
     return [name, api, model_id, rag_context, query, llm_response, reference]
 
 
-allowed_models = ["mistral.mistral-large-2402-v1:0"]
-task_generator = TaskGenerator()
+allowed_models = ["gpt-4o-mini"]
+task_generator = TaskGenerator(allowed_models=allowed_models)
 rows =[]
 for i in range(num_to_generate):
     print(i)


### PR DESCRIPTION
Incomplete contexts were being pulled from wikipedia affecting relevancy tasks leading to:
1. misssing context strings
2. errors from missing contexts 

This PR fixes:
- ensures that we always correctly handle the wikipedia context 
- given the above, we prevent the downstream errors 