### PR TITLE
Turn on Weights for Mistake Identification

### DIFF
--- a/deval/tasks/attribution.py
+++ b/deval/tasks/attribution.py
@@ -89,12 +89,12 @@ class AttributionTask(Task):
     tool_schema_generator = ToolSchemaGenerator(name, desc, properties, required_values)
 
     reward_definition = [
-        dict(name="float_diff", weight=1.0, reference_type = RewardReferenceType.SCORE),
-        dict(name="exact_match", weight=0, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="float_diff", weight=0.5, reference_type = RewardReferenceType.SCORE),
+        dict(name="exact_match", weight=0.5, reference_type = RewardReferenceType.MISTAKES),
     ]
     penalty_definition = [
-        dict(name="dist_penalty", weight=0.5, reference_type = RewardReferenceType.SCORE),
-        dict(name="exact_match", weight=0, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="dist_penalty", weight=0.25, reference_type = RewardReferenceType.SCORE),
+        dict(name="exact_match", weight=0.5, reference_type = RewardReferenceType.MISTAKES),
     ]
 
     def __init__(self, llm_pipeline, context):

--- a/deval/tasks/hallucination.py
+++ b/deval/tasks/hallucination.py
@@ -84,12 +84,12 @@ class HallucinationTask(Task):
 
 
     reward_definition = [
-        dict(name="float_diff", weight=1.0, reference_type = RewardReferenceType.SCORE),
-        dict(name="exact_match", weight=0.0, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="float_diff", weight=0.5, reference_type = RewardReferenceType.SCORE),
+        dict(name="exact_match", weight=0.5, reference_type = RewardReferenceType.MISTAKES),
     ]
     penalty_definition = [
-        dict(name="dist_penalty", weight=0.5, reference_type = RewardReferenceType.SCORE),
-        dict(name="exact_match", weight=0.0, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="dist_penalty", weight=0.25, reference_type = RewardReferenceType.SCORE),
+        dict(name="exact_match", weight=0.5, reference_type = RewardReferenceType.MISTAKES),
     ]
 
     def __init__(self, llm_pipeline, context):

--- a/deval/tasks/summary_completeness.py
+++ b/deval/tasks/summary_completeness.py
@@ -71,14 +71,14 @@ class CompletenessTask(Task):
     tool_schema_generator = ToolSchemaGenerator(name, desc, properties, required_values)
 
     reward_definition = [
-        dict(name="float_diff", weight=1.0, reference_type = RewardReferenceType.SCORE),
-        dict(name="rouge", weight=0.0, reference_type = RewardReferenceType.MISTAKES),
-        dict(name="relevance", weight=0.0, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="float_diff", weight=0.5, reference_type = RewardReferenceType.SCORE),
+        dict(name="rouge", weight=0.25, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="relevance", weight=0.25, reference_type = RewardReferenceType.MISTAKES),
     ]
     penalty_definition = [
-        dict(name="dist_penalty", weight=0.5, reference_type = RewardReferenceType.SCORE),
-        dict(name="rouge", weight=0.0, reference_type = RewardReferenceType.MISTAKES),
-        dict(name="relevance", weight=0.0, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="dist_penalty", weight=0.25, reference_type = RewardReferenceType.SCORE),
+        dict(name="rouge", weight=0.125, reference_type = RewardReferenceType.MISTAKES),
+        dict(name="relevance", weight=0.125, reference_type = RewardReferenceType.MISTAKES),
     ]
 
     def __init__(self, llm_pipeline, context):


### PR DESCRIPTION
Previous PR added the ability to identify mistakes, this turns on weights so that these predictions impact rewards. 